### PR TITLE
Return 200 for incomplete reimbursement errors

### DIFF
--- a/lib/spree/wombat/handler/add_customer_return_handler.rb
+++ b/lib/spree/wombat/handler/add_customer_return_handler.rb
@@ -25,6 +25,9 @@ module Spree
           else
             response "Customer return could not be created, errors: #{customer_return.errors.full_messages}", 400
           end
+        rescue Spree::Reimbursement::IncompleteReimbursement
+          # These items need manual intervention and will be identified and handled separately
+          response "Customer return #{customer_return.id} processed but not fully reimbursed", 200
         rescue => e
           response "Customer return could not be fully processed, errors: #{e}", 500
         end

--- a/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
-shared_examples "receives the return items" do
-
+shared_examples "receives the return items" do |message=/Customer return \d+ was added/|
   it "succeeds" do
-    expect(responder.summary).to match /Customer return \d+ was added/
+    expect(responder.summary).to match message
     expect(responder.code).to eql 200
   end
 
@@ -28,7 +27,11 @@ shared_examples "receives the return items" do
 
   it "attempts to accept all of the return items" do
     accept_count = 0
-    Spree::ReturnItem.any_instance.stub(:attempt_accept) { accept_count += 1 }
+    original_method = Spree::ReturnItem.instance_method(:attempt_accept)
+    Spree::ReturnItem.any_instance.stub(:attempt_accept) do |return_item|
+      accept_count += 1
+      original_method.bind(return_item).call
+    end
     subject
     expect(accept_count).to eq 3
   end
@@ -149,6 +152,15 @@ module Spree
               end
               it_behaves_like "receives the return items"
               it_behaves_like "does not attempt to refund the customer"
+            end
+
+            context "the customer return raises an IncompleteReimbursement error" do
+              before do
+                expect_any_instance_of(Spree::Reimbursement).to(
+                  receive(:perform!).and_raise(Spree::Reimbursement::IncompleteReimbursement)
+                )
+              end
+              it_behaves_like "receives the return items", /Customer return \d+ processed but not fully reimbursed/
             end
           end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :deletion
     DatabaseCleaner.clean_with :truncation
   end
+
+  config.mock_with :rspec do |mocks|
+    mocks.yield_receiver_to_any_instance_implementation_blocks = true
+  end
 end
 
 class Spree::Wombat::Handler::MyCustomHandler < Spree::Wombat::Handler::Base


### PR DESCRIPTION
These do not need any further processing by wombat.  They need to be
picked up by customer service and processed manually. Thus, there's
not much point to marking them as failed in Wombat.

It makes me a little nervous to return a 200 OK in a situation like
this but from wombat's perspective there isn't anything further to
do and the alternative of spamming wombat with extraneous failures
seems worse.