### PR TITLE
Log response summaries for error responses

### DIFF
--- a/app/controllers/spree/wombat/webhook_controller.rb
+++ b/app/controllers/spree/wombat/webhook_controller.rb
@@ -46,6 +46,9 @@ module Spree
             error_notifier.call(responder)
           end
         end
+        if responder.code >= 400
+          logger.info "responder_summary=#{responder.summary.inspect}"
+        end
         render(
           json: ResponderSerializer.new(responder, root: false),
           status: responder.code


### PR DESCRIPTION
For all response codes >= 400, even when there is no exception involved.