### PR TITLE
when taxons are not present, do not empty the products' taxon list

### DIFF
--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -5,7 +5,7 @@ module Spree
     module Handler
       class ProductHandlerBase < Base
 
-        attr_accessor :params, :children_params, :master_images, :taxon_ids,
+        attr_accessor :params, :children_params, :master_images, :taxons, :taxon_ids,
                       :root_options, :properties
 
         def initialize(message)
@@ -16,12 +16,13 @@ module Spree
           #posible master images
           @master_images = @params.delete(:images)
           @taxon_ids = []
+          @taxons_list = @params.delete(:taxons)
         end
 
         def root_product_attrs
           permalink = @params.delete(:permalink)
           shipping_category_name = @params.delete(:shipping_category)
-          process_taxons(@params.delete(:taxons))
+          process_taxons(@taxons_list)
           @root_options = @params.delete(:options)
           @properties = @params.delete(:properties)
 
@@ -33,7 +34,7 @@ module Spree
           sku = @params[:sku]
           @params = @params.slice *Spree::Product.attribute_names
           @params.delete(:id) # Reject ID as it should be set by database or else it could convert to 0 in postgresql.
-          @params[:taxon_ids] = Spree::Taxon.where(id: @taxon_ids).leaves.pluck(:id)
+          @params[:taxon_ids] = Spree::Taxon.where(id: @taxon_ids).leaves.pluck(:id) unless @taxons_list.nil?
           @params[:price] = price
           @params[:sku] = sku
           @params

--- a/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
@@ -46,6 +46,58 @@ module Spree
           end
         end
 
+        context "and regarding taxons" do
+          let(:message_without_taxons) do
+            message["product"].delete("taxons")
+            message
+          end
+
+          let(:message_with_empty_taxons) do
+            message["product"]["taxons"] = []
+            message
+          end
+
+          let(:message_with_different_taxons) do
+            message["product"]["taxons"] = [["Categories", "Scuba Gear"], ["Brands", "Scuba"]]
+            message
+          end
+
+          let(:handler_without_taxons) { Handler::UpdateProductHandler.new(message_without_taxons.to_json) }
+          let(:handler_with_empty_taxons) { Handler::UpdateProductHandler.new(message_with_empty_taxons.to_json) }
+          let(:handler_with_different_taxons) { Handler::UpdateProductHandler.new(message_with_different_taxons.to_json) }
+
+          let(:product) { Spree::Variant.find_by_sku(message["product"]["sku"]).product }
+
+          before do
+            handler.process
+          end
+
+          it "updates a product with taxons" do
+            expect(product.taxons.size).to eq 3
+          end
+
+          it "updates a product without taxons" do
+            expect(product.taxons.size).to eq 3
+
+            handler_without_taxons.process
+            expect(product.taxons.size).to eq 3
+          end
+
+          it "updates a product with empty taxons" do
+            expect(product.taxons.size).to eq 3
+
+            handler_with_empty_taxons.process
+            expect(product.taxons.size).to eq 0
+          end
+
+          it "updates a product with different taxons" do
+            expect(product.taxons.size).to eq 3
+
+            handler_with_different_taxons.process
+            expect(product.taxons.size).to eq 2
+          end
+        end
+
 
         context "response" do
           let(:responder) { handler.process }


### PR DESCRIPTION
Hello,
using wombat I realized that when I removed the taxons value from my json payload, the product would end up with empty taxons after the update, because @taxon_ids would be empty.

Hope this helps.