### PR TITLE
Dont duplicate deleted variants on product webhooks

### DIFF
--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -122,7 +122,9 @@ module Spree
             child_product = child_product.slice *Spree::Variant.attribute_names
             child_product[:options] = option_type_values.collect {|k,v| {name: k, value: v} }
             child_product[:price] = price
-            variant = product.variants.find_by_sku(child_product[:sku])
+
+            variant = product.variants.unscoped.find_by_sku(child_product[:sku])
+
             if variant
               variant.update_attributes(child_product)
             else

--- a/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
@@ -14,6 +14,34 @@ module Spree
         expect(response.summary).to match "Cannot find product with SKU"
       end
 
+      it "doesnt create duplicated variant" do
+        message = {
+          product: {
+            name: 'rails',
+            sku: 'rails',
+            shipping_category: 'default',
+            price: 30,
+            variants: [
+              {
+                sku: 'not rails',
+                deleted_at: Time.now,
+                options: []
+              }
+            ]
+          }
+        }
+
+        expect {
+          handler = Handler::AddProductHandler.new message.to_json
+          handler.process
+        }.to change { Variant.unscoped.count }.by(2)
+
+        expect {
+          handler = described_class.new message.to_json
+          response = handler.process
+        }.not_to change { Variant.unscoped.count }
+      end
+
       context "#process" do
         let!(:message) do
           hsh = ::Hub::Samples::Product.request


### PR DESCRIPTION
Just noticed that every time you update a product with a deleted variant spree_wombat handler will create a new one and [zero the stock of the previous master variant](https://github.com/spree/spree/blob/e87112027ff3729bfa76749b744cd28faabf3c44/core/app/models/spree/variant.rb#L193-198).

This should prevent those from happening, I'm submitting this to review just in case I'm not missing anything here.