### PR TITLE
product.variants.unscoped finds variants outside of the product scope

### DIFF
--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -123,13 +123,9 @@ module Spree
             child_product[:options] = option_type_values.collect {|k,v| {name: k, value: v} }
             child_product[:price] = price
 
-            variant = product.variants.unscoped.find_by_sku(child_product[:sku])
+            variant = Spree::Variant.unscoped.where(sku: child_product[:sku], product: product).first_or_initialize
+            variant.update_attributes!(child_product)
 
-            if variant
-              variant.update_attributes(child_product)
-            else
-              variant = product.variants.create!({ product: product }.merge(child_product))
-            end
             process_images(variant, images)
           end
         end


### PR DESCRIPTION
Somehow, the product.variants.unscoped can get all variants, disregarding the parent product.

I've changed the code to prevent this from happening, since I was having issues with deleted variants from a deleted product being selected, instead of creating a new one in a new product.

I believe this will still get the deleted variant if the parent product match, which to me, seems to be the expected behavior. Correct?

Please let me know what you think.