### PR TITLE
adds set_price handler

### DIFF
--- a/lib/spree/wombat.rb
+++ b/lib/spree/wombat.rb
@@ -21,6 +21,8 @@ require 'spree/wombat/handler/update_order_handler'
 
 require 'spree/wombat/handler/set_inventory_handler'
 
+require 'spree/wombat/handler/set_price_handler'
+
 require 'spree/wombat/handler/add_shipment_handler'
 require 'spree/wombat/handler/update_shipment_handler'
 

--- a/lib/spree/wombat/handler/set_price_handler.rb
+++ b/lib/spree/wombat/handler/set_price_handler.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Wombat
+    module Handler
+      class SetPriceHandler < Base
+        def process
+          sku = @payload[:price].delete(:product_id)
+          variant = Spree::Variant.find_by_sku(sku)
+          return response("Product with SKU #{sku} was not found", 500) unless variant
+
+          updatable_columns = @payload[:price].slice *Spree::Variant.attribute_names.select{|n| n =~ /price/i }.concat(["price"])
+          return response("Missing price information", 500) unless updatable_columns[:price]
+
+          current_price = variant.price
+          current_currency = variant.currency
+
+          Spree::Variant.transaction do
+            variant.update_attributes!(updatable_columns)
+          end
+
+          return response("Set price for #{sku} from #{current_price} #{current_currency} to #{variant.reload.price} #{variant.reload.currency}")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/spree/wombat/handler/set_price_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/set_price_handler_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+module Spree
+  module Wombat
+    describe Handler::SetPriceHandler do
+      let(:message) {::Hub::Samples::Price.request}
+      let(:handler) { Handler::SetPriceHandler.new(message.to_json) }
+
+      describe "process" do
+        context "with stock item present" do
+          let!(:variant) { create(:variant, :sku => 'SPREE-T-SHIRT', price: 12.0, cost_price: 5.0) }
+
+          context "and the stock location name is equal to location in the message" do
+            it "will set the price to the supplied amount" do
+              expect{handler.process}.to change{variant.reload.price.to_f}.from(12.0).to(12.95)
+            end
+
+            it "will set the cost_price to the supplied amount" do
+              expect{handler.process}.to change{variant.reload.cost_price.to_f}.from(5.0).to(6.25)
+            end
+
+            it "returns a Hub::Responder with a proper message" do
+              responder = handler.process
+              expect(responder.summary).to eql "Set price for SPREE-T-SHIRT from 12.0 USD to 12.95 USD"
+              expect(responder.code).to eql 200
+            end
+          end
+        end
+
+        context "with variant not present" do
+          it "returns a Hub::Responder with 500 status" do
+            responder = handler.process
+            expect(responder.summary).to eql "Product with SKU SPREE-T-SHIRT was not found"
+            expect(responder.code).to eql 500
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds a set_price endpoint, if you think it would be useful to add anything else, I'll be happy to make any changes.

Right now, there is a dependency pointing to my hub_samples fork.
The change is not necessary after the PR to add a price sample is considered and approved.

hub_samples PR:
https://github.com/spree/hub_samples/pull/4

Please consider this.

Thank you.