### PR TITLE
Changes Version of 'active_model_serializers' Dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+# before_script:
+#   - bundle exec rake test_app
+#   - export DISPLAY=:99.0
+#   - sh -e /etc/init.d/xvfb start
+env:
+  - DB=mysql
+  - DB=postgres
+language: ruby
+rvm:
+  - 2.1.5
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ env:
   - DB=postgres
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.2
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,22 +2,9 @@ source 'https://rubygems.org'
 
 gem 'spree', github: 'spree/spree', branch: "master"
 
-gem 'coffee-rails', '~> 4.0.0'
-gem 'sass-rails', '~> 4.0.0'
-
-gem 'mysql2'
-gem 'pg'
-
 group :test do
   gem 'hub_samples', github: "spree/hub_samples", branch: "master"
-  gem 'timecop'
-
-  platforms :ruby_19 do
-    gem 'pry-debugger'
-  end
-  platforms :ruby_20, :ruby_21 do
-    gem 'pry-byebug'
-  end
+  gem 'pry-byebug'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '3-0-stable'
+gem 'spree', github: 'spree/spree', branch: 'master'
 
 group :test do
   gem 'hub_samples', github: "spree/hub_samples", branch: "master"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: '3-0-stable'
 
 group :test do
   gem 'hub_samples', github: "spree/hub_samples", branch: "master"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: "master"
+gem 'spree', github: 'spree/spree', branch: 'master'
 
 group :test do
   gem 'hub_samples', github: "spree/hub_samples", branch: "master"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'spree', github: 'spree/spree', branch: "master"
 gem 'coffee-rails', '~> 4.0.0'
 gem 'sass-rails', '~> 4.0.0'
 
+gem 'mysql2'
 gem 'pg'
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Connect your SpreeCommerce Storefront to Wombat, providing push API and webhook handlers
 
+[![Build Status](https://travis-ci.org/spree/spree_wombat.svg?branch=refactor-client-wombat-ruby)](https://travis-ci.org/spree/spree_wombat)
+
 ## Installation
 
 Add spree_wombat to your Gemfile:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Connect your SpreeCommerce Storefront to Wombat, providing push API and webhook handlers
 
-[![Build Status](https://travis-ci.org/spree/spree_wombat.svg?branch=refactor-client-wombat-ruby)](https://travis-ci.org/spree/spree_wombat)
+[![Build Status](https://travis-ci.org/spree/spree_wombat.svg?branch=master)](https://travis-ci.org/spree/spree_wombat)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ Spree::Wombat::Config[:last_pushed_timestamps] = timestamps
 
 This will update the preference in the database and will use your updated timestamp for, in this case, 'Spree::Order'
 
+### WebhookController.error_notifier
+
+If you would like to forward WebhookController exceptions to an error
+notification tool you can configure the `WebhookController.error_notifier`
+property with an object that responds to `#call` and accepts the responder as an
+argument. e.g. with a proc:
+
+```ruby
+# in config/initializers/wombat.rb:
+Rails.application.config.to_prepare do
+  WebhookController.error_notifier = ->(responder) do
+    Honeybadger.notify(responder.exception)
+  end
+end
+```
+
 ## Push to Wombat
 
 To push objects to Wombat we provide you with the following rake task:

--- a/app/controllers/spree/wombat/webhook_controller.rb
+++ b/app/controllers/spree/wombat/webhook_controller.rb
@@ -46,6 +46,9 @@ module Spree
             error_notifier.call(responder)
           end
         end
+        if responder.code >= 400
+          logger.info "responder_summary=#{responder.summary.inspect}"
+        end
         render(
           json: ResponderSerializer.new(responder, root: false),
           status: responder.code

--- a/app/controllers/spree/wombat/webhook_controller.rb
+++ b/app/controllers/spree/wombat/webhook_controller.rb
@@ -1,14 +1,19 @@
 module Spree
   module Wombat
     class WebhookController < ActionController::Base
+      # Applications can use error_notifier to forward errors to tools like
+      # airbrake, honeybadger, rollbar, etc.
+      # This should be an object that responds to `call` and accepts the
+      # responder as an argument.
+      class_attribute :error_notifier
+
       before_filter :save_request_data, :authorize
       rescue_from Exception, :with => :exception_handler
 
       def consume
         handler = Handler::Base.build_handler(@called_hook, @webhook_body)
         responder = handler.process
-        render json: responder, root: false, status: responder.code
-        #render json: ResponderSerializer.new(responder, root: false), status: responder.code
+        render_responder(responder)
       end
 
       protected
@@ -16,18 +21,15 @@ module Spree
         unless request.headers['HTTP_X_HUB_TOKEN'] == Spree::Wombat::Config[:connection_token]
           base_handler = Handler::Base.new(@webhook_body)
           responder = base_handler.response('Unauthorized!', 401)
-          render json: responder, root: false, status: responder.code
+          render_responder(responder)
           return false
         end
       end
 
       def exception_handler(exception)
         base_handler = Handler::Base.new(@webhook_body)
-        logger.error exception
-        logger.error exception.backtrace.join("\n").to_s
-        responder = base_handler.response(exception.message, 500)
-        responder.backtrace = exception.backtrace.to_s
-        render json: responder, root: false, status: responder.code
+        responder = base_handler.response(exception.message, 500, nil, exception)
+        render_responder(responder)
         return false
       end
 
@@ -36,6 +38,19 @@ module Spree
         @webhook_body = request.body.read
       end
 
+      def render_responder(responder)
+        if responder.exception
+          logger.error responder.exception
+          logger.error responder.exception.backtrace.join("\n").to_s
+          if error_notifier
+            error_notifier.call(responder)
+          end
+        end
+        render(
+          json: ResponderSerializer.new(responder, root: false),
+          status: responder.code
+        )
+      end
     end
   end
 end

--- a/app/models/spree/wombat_configuration.rb
+++ b/app/models/spree/wombat_configuration.rb
@@ -6,7 +6,7 @@ module Spree
     preference :push_url, :string, :default => 'https://push.wombat.co'
     preference :push_objects, :array, :default => ["Spree::Order", "Spree::Product"]
     preference :payload_builder, :hash, :default => {
-      "Spree::Order" => {:serializer => "Spree::Wombat::OrderSerializer", :root => "orders"},
+      "Spree::Order" => {:serializer => "Spree::Wombat::OrderSerializer", :root => "orders", :filter => "complete"},
       "Spree::Product" => {:serializer => "Spree::Wombat::ProductSerializer", :root => "products"},
     }
     preference :last_pushed_timestamps, :hash, :default => {

--- a/app/serializers/spree/wombat/address_serializer.rb
+++ b/app/serializers/spree/wombat/address_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/adjustment_serializer.rb
+++ b/app/serializers/spree/wombat/adjustment_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/customer_return_serializer.rb
+++ b/app/serializers/spree/wombat/customer_return_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/image_serializer.rb
+++ b/app/serializers/spree/wombat/image_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/inventory_unit_serializer.rb
+++ b/app/serializers/spree/wombat/inventory_unit_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/line_item_serializer.rb
+++ b/app/serializers/spree/wombat/line_item_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/order_serializer.rb
+++ b/app/serializers/spree/wombat/order_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/order_serializer.rb
+++ b/app/serializers/spree/wombat/order_serializer.rb
@@ -9,6 +9,7 @@ module Spree
 
       has_many :line_items,  serializer: Spree::Wombat::LineItemSerializer
       has_many :payments, serializer: Spree::Wombat::PaymentSerializer
+      has_many :promotions, serializer: Spree::Wombat::PromotionSerializer
 
       has_one :shipping_address, serializer: Spree::Wombat::AddressSerializer
       has_one :billing_address, serializer: Spree::Wombat::AddressSerializer

--- a/app/serializers/spree/wombat/order_serializer.rb
+++ b/app/serializers/spree/wombat/order_serializer.rb
@@ -54,7 +54,7 @@ module Spree
 
       def adjustments
         [
-          { name: 'discount', value: adjustment_total },
+          { name: 'discount', value: object.promo_total.to_f },
           { name: 'tax', value: tax_total },
           { name: 'shipping', value: shipping_total }
         ]
@@ -71,7 +71,15 @@ module Spree
         end
 
         def tax_total
-          object.tax_total.to_f
+          tax = 0.0
+          tax_rate_taxes = (object.included_tax_total + object.additional_tax_total).to_f
+          manual_import_adjustment_tax_adjustments = object.adjustments.select{|adjustment| adjustment.label.downcase == "tax" && adjustment.source_id == nil && adjustment.source_type == nil}
+          if(tax_rate_taxes == 0.0 && manual_import_adjustment_tax_adjustments.present?)
+            tax = manual_import_adjustment_tax_adjustments.sum(&:amount).to_f
+          else
+            tax = tax_rate_taxes
+          end
+          tax
         end
 
     end

--- a/app/serializers/spree/wombat/payment_serializer.rb
+++ b/app/serializers/spree/wombat/payment_serializer.rb
@@ -7,10 +7,6 @@ module Spree
 
       has_one :source, serializer: Spree::Wombat::SourceSerializer
 
-      def number
-        object.identifier
-      end
-
       def payment_method
         object.payment_method.name
       end

--- a/app/serializers/spree/wombat/payment_serializer.rb
+++ b/app/serializers/spree/wombat/payment_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/product_serializer.rb
+++ b/app/serializers/spree/wombat/product_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat
@@ -6,8 +6,14 @@ module Spree
 
       attributes :id, :name, :sku, :description, :price, :cost_price,
                  :available_on, :permalink, :meta_description, :meta_keywords,
-                 :shipping_category, :taxons, :options, :weight, :height, :width,
+                 :shipping_category, :taxons, :weight, :height, :width,
                  :depth, :variants
+
+      def attributes
+        super.tap do |hash|
+          hash.update(options: options_text)
+        end
+      end
 
       has_many :images, serializer: Spree::Wombat::ImageSerializer
 
@@ -39,7 +45,7 @@ module Spree
         object.taxons.collect {|t| t.self_and_ancestors.collect(&:name)}
       end
 
-      def options
+      def options_text
         object.option_types.pluck(:name)
       end
 

--- a/app/serializers/spree/wombat/product_serializer.rb
+++ b/app/serializers/spree/wombat/product_serializer.rb
@@ -6,10 +6,10 @@ module Spree
 
       attributes :id, :name, :sku, :description, :price, :cost_price,
                  :available_on, :permalink, :meta_description, :meta_keywords,
-                 :shipping_category, :taxons, :options, :weight, :height, :width, :depth
+                 :shipping_category, :taxons, :options, :weight, :height, :width,
+                 :depth, :variants
 
       has_many :images, serializer: Spree::Wombat::ImageSerializer
-      has_many :variants_including_master, serializer: Spree::Wombat::VariantSerializer, root: "variants"
 
       def id
         object.sku
@@ -43,6 +43,17 @@ module Spree
         object.option_types.pluck(:name)
       end
 
+      def variants
+        if object.variants.empty?
+          [Spree::Wombat::VariantSerializer.new(object.master, root:false)]
+        else
+          ActiveModel::ArraySerializer.new(
+            object.variants,
+            each_serializer: Spree::Wombat::VariantSerializer,
+            root: false
+          )
+        end
+      end
     end
   end
 end

--- a/app/serializers/spree/wombat/promotion_serializer.rb
+++ b/app/serializers/spree/wombat/promotion_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/promotion_serializer.rb
+++ b/app/serializers/spree/wombat/promotion_serializer.rb
@@ -1,0 +1,17 @@
+require 'active_model/serializer'
+
+module Spree
+  module Wombat
+    class PromotionSerializer < ActiveModel::Serializer
+      attributes :name, :code, :category_name, :category_code
+
+      def category_name
+        object.promotion_category.try(:name)
+      end
+
+      def category_code
+        object.promotion_category.try(:code)
+      end
+    end
+  end
+end

--- a/app/serializers/spree/wombat/refund_serializer.rb
+++ b/app/serializers/spree/wombat/refund_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/reimbursement_serializer.rb
+++ b/app/serializers/spree/wombat/reimbursement_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/responder_serializer.rb
+++ b/app/serializers/spree/wombat/responder_serializer.rb
@@ -6,7 +6,7 @@ module Spree
       attributes :request_id, :summary, :backtrace, :objects
 
       def filter(keys)
-        keys.delete(:backtrace) unless object.backtrace.present?
+        keys.delete(:backtrace) if object.exception.nil?
         keys.delete(:objects) unless object.objects.present?
         keys
       end
@@ -22,6 +22,11 @@ module Spree
 
         hash
       end
+
+      def backtrace
+        object.exception.backtrace.to_s if object.exception
+      end
+
     end
   end
 end

--- a/app/serializers/spree/wombat/responder_serializer.rb
+++ b/app/serializers/spree/wombat/responder_serializer.rb
@@ -1,18 +1,15 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat
     class ResponderSerializer < ActiveModel::Serializer
       attributes :request_id, :summary, :backtrace, :objects
 
-      def filter(keys)
-        keys.delete(:backtrace) if object.exception.nil?
-        keys.delete(:objects) unless object.objects.present?
-        keys
-      end
-
       def attributes
         hash = super
+
+        hash.delete(:backtrace) if object.exception.nil?
+        hash.delete(:objects) unless object.objects.present?
 
         if objects = hash.delete(:objects)
           objects.each do |key, array_of_objects|

--- a/app/serializers/spree/wombat/return_item_serializer.rb
+++ b/app/serializers/spree/wombat/return_item_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/return_item_serializer.rb
+++ b/app/serializers/spree/wombat/return_item_serializer.rb
@@ -6,7 +6,7 @@ module Spree
       attributes :id, :return_authorization_id, :product_id, :exchange_product_id,
         :reception_status, :acceptance_status, :pre_tax_amount, :included_tax_total,
         :additional_tax_total, :order_number, :created_at, :reimbursed_at, :reimbursed,
-        :store
+        :store, :resellable
 
       def product_id
         inventory_unit.variant.sku

--- a/app/serializers/spree/wombat/return_item_serializer.rb
+++ b/app/serializers/spree/wombat/return_item_serializer.rb
@@ -3,7 +3,7 @@ require 'active_model/serializer'
 module Spree
   module Wombat
     class ReturnItemSerializer < ActiveModel::Serializer
-      attributes :return_authorization_id, :product_id, :exchange_product_id,
+      attributes :id, :return_authorization_id, :product_id, :exchange_product_id,
         :reception_status, :acceptance_status, :pre_tax_amount, :included_tax_total,
         :additional_tax_total, :order_number, :created_at, :reimbursed_at, :reimbursed,
         :store

--- a/app/serializers/spree/wombat/return_item_serializer.rb
+++ b/app/serializers/spree/wombat/return_item_serializer.rb
@@ -5,10 +5,11 @@ module Spree
     class ReturnItemSerializer < ActiveModel::Serializer
       attributes :return_authorization_id, :product_id, :exchange_product_id,
         :reception_status, :acceptance_status, :pre_tax_amount, :included_tax_total,
-        :additional_tax_total
+        :additional_tax_total, :order_number, :created_at, :reimbursed_at, :reimbursed,
+        :store
 
       def product_id
-        object.inventory_unit.variant.sku
+        inventory_unit.variant.sku
       end
 
       def exchange_product_id
@@ -17,6 +18,36 @@ module Spree
 
       def return_authorization_id
         object.return_authorization.try(:number)
+      end
+
+      def order_number
+        order.number
+      end
+
+      def reimbursed_at
+        reimbursement.try(:created_at)
+      end
+
+      def reimbursed
+        !!reimbursement
+      end
+
+      def store
+        order.store.code
+      end
+
+      private
+
+      def inventory_unit
+        object.inventory_unit
+      end
+
+      def reimbursement
+        object.reimbursement
+      end
+
+      def order
+        inventory_unit.order
       end
     end
   end

--- a/app/serializers/spree/wombat/return_item_serializer.rb
+++ b/app/serializers/spree/wombat/return_item_serializer.rb
@@ -33,7 +33,7 @@ module Spree
       end
 
       def store
-        order.store.code
+        order.store.try(:code)
       end
 
       private

--- a/app/serializers/spree/wombat/shipment_serializer.rb
+++ b/app/serializers/spree/wombat/shipment_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat
@@ -7,8 +7,8 @@ module Spree
                 :shipping_method, :tracking, :placed_on, :shipped_at, :totals,
                 :updated_at, :channel, :items
 
-      has_one :bill_to, serializer: AddressSerializer, root: "billing_address"
-      has_one :ship_to, serializer: AddressSerializer, root: "shipping_address"
+      has_one :bill_to, serializer: AddressSerializer, key: "billing_address"
+      has_one :ship_to, serializer: AddressSerializer, key: "shipping_address"
 
       def id
         object.number

--- a/app/serializers/spree/wombat/source_serializer.rb
+++ b/app/serializers/spree/wombat/source_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/stock_item_serializer.rb
+++ b/app/serializers/spree/wombat/stock_item_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/variant_serializer.rb
+++ b/app/serializers/spree/wombat/variant_serializer.rb
@@ -1,11 +1,17 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat
     class VariantSerializer < ActiveModel::Serializer
 
-      attributes :sku, :price, :cost_price, :options, :weight, :height, :width, :depth
+      attributes :sku, :price, :cost_price, :weight, :height, :width, :depth
       has_many :images, serializer: Spree::Wombat::ImageSerializer
+
+      def attributes
+        super.tap do |hash|
+          hash.update(options: options_text)
+        end
+      end
 
       def price
         object.price.to_f
@@ -15,7 +21,7 @@ module Spree
         object.cost_price.to_f
       end
 
-      def options
+      def options_text
         object.option_values.each_with_object({}) {|ov,h| h[ov.option_type.presentation]= ov.presentation}
       end
 

--- a/lib/generators/spree_wombat/serializer/templates/serializer.rb.tt
+++ b/lib/generators/spree_wombat/serializer/templates/serializer.rb.tt
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 <% if superclass != "ActiveModel::Serializer" %>
 # inherit from ActiveModel::Serializer if you want to completely replace the existing serializer
 <% end %>

--- a/lib/spree/wombat.rb
+++ b/lib/spree/wombat.rb
@@ -21,6 +21,8 @@ require 'spree/wombat/handler/update_order_handler'
 
 require 'spree/wombat/handler/set_inventory_handler'
 
+require 'spree/wombat/handler/set_price_handler'
+
 require 'spree/wombat/handler/add_shipment_handler'
 require 'spree/wombat/handler/update_shipment_handler'
 

--- a/lib/spree/wombat/client.rb
+++ b/lib/spree/wombat/client.rb
@@ -10,7 +10,7 @@ module Spree
       def self.push_batches(object, ts_offset = 5)
         object_count = 0
 
-        last_push_time = Spree::Wombat::Config[:last_pushed_timestamps][object] || Time.now
+        last_push_time = Spree::Wombat::Config[:last_pushed_timestamps][object] || Time.at(0)
         this_push_time = Time.now
 
         payload_builder = Spree::Wombat::Config[:payload_builder][object]

--- a/lib/spree/wombat/client.rb
+++ b/lib/spree/wombat/client.rb
@@ -7,7 +7,7 @@ module Spree
   module Wombat
     class Client
 
-      def self.push_batches(object)
+      def self.push_batches(object, ts_offset = 5)
         object_count = 0
 
         last_push_time = Spree::Wombat::Config[:last_pushed_timestamps][object] || Time.now
@@ -22,6 +22,9 @@ module Spree
         if filter = payload_builder[:filter]
           scope = scope.send(filter.to_sym)
         end
+
+        # go 'ts_offset' seconds back in time to catch missing objects
+        last_push_time = last_push_item - ts_offset.seconds
 
         scope.where(updated_at: last_push_time...this_push_time).find_in_batches(batch_size: Spree::Wombat::Config[:batch_size]) do |batch|
           object_count += batch.size

--- a/lib/spree/wombat/client.rb
+++ b/lib/spree/wombat/client.rb
@@ -15,7 +15,9 @@ module Spree
 
         payload_builder = Spree::Wombat::Config[:payload_builder][object]
 
-        scope = object.constantize
+        model_name = payload_builder[:model].present? ? payload_builder[:model] : object
+
+        scope = model_name.constantize
 
         if filter = payload_builder[:filter]
           scope = scope.send(filter.to_sym)

--- a/lib/spree/wombat/client.rb
+++ b/lib/spree/wombat/client.rb
@@ -24,7 +24,7 @@ module Spree
         end
 
         # go 'ts_offset' seconds back in time to catch missing objects
-        last_push_time = last_push_item - ts_offset.seconds
+        last_push_time = last_push_time - ts_offset.seconds
 
         scope.where(updated_at: last_push_time...this_push_time).find_in_batches(batch_size: Spree::Wombat::Config[:batch_size]) do |batch|
           object_count += batch.size

--- a/lib/spree/wombat/client.rb
+++ b/lib/spree/wombat/client.rb
@@ -29,10 +29,10 @@ module Spree
             root: payload_builder[:root]
           ).to_json
 
-          push(payload)
+          push(payload) unless object_count == 0
         end
 
-        update_last_pushed(object, this_push_time)
+        update_last_pushed(object, this_push_time) unless object_count == 0
         object_count
       end
 

--- a/lib/spree/wombat/handler/add_customer_handler.rb
+++ b/lib/spree/wombat/handler/add_customer_handler.rb
@@ -10,7 +10,7 @@ module Spree
           end
 
           user = Spree.user_class.new(email: email)
-          user.save(validation: false)
+          user.save(validate: false)
 
           firstname = @payload["customer"]["firstname"]
           lastname = @payload["customer"]["lastname"]

--- a/lib/spree/wombat/handler/add_customer_return_handler.rb
+++ b/lib/spree/wombat/handler/add_customer_return_handler.rb
@@ -25,7 +25,7 @@ module Spree
           else
             response "Customer return could not be created, errors: #{customer_return.errors.full_messages}", 400
           end
-        rescue Spree::Reimbursement::IncompleteReimbursement
+        rescue Spree::Reimbursement::IncompleteReimbursementError
           # These items need manual intervention and will be identified and handled separately
           response "Customer return #{customer_return.id} processed but not fully reimbursed", 200
         rescue => e

--- a/lib/spree/wombat/handler/add_customer_return_handler.rb
+++ b/lib/spree/wombat/handler/add_customer_return_handler.rb
@@ -25,6 +25,9 @@ module Spree
           else
             response "Customer return could not be created, errors: #{customer_return.errors.full_messages}", 400
           end
+        rescue Spree::Reimbursement::IncompleteReimbursement
+          # These items need manual intervention and will be identified and handled separately
+          response "Customer return #{customer_return.id} processed but not fully reimbursed", 200
         rescue => e
           response "Customer return could not be fully processed, errors: #{e}", 500
         end

--- a/lib/spree/wombat/handler/add_customer_return_handler.rb
+++ b/lib/spree/wombat/handler/add_customer_return_handler.rb
@@ -8,8 +8,15 @@ module Spree
 
           customer_return = CustomerReturn.new(stock_location: stock_location, return_items: return_items)
 
+          if customer_return.return_items.length == 0
+            received_items = return_items(true)
+            if received_items.present? && received_items.length == intended_quantity
+              return response("Customer return #{received_items.first.customer_return.number} has already been processed", 200)
+            end
+          end
+
           if customer_return.return_items.length != intended_quantity
-            raise "Unable to create the requested amount of return items"
+            return response("Unable to create the requested amount of return items", 500)
           end
 
           if customer_return.save
@@ -28,11 +35,11 @@ module Spree
           StockLocation.find_by!(name: customer_return_params[:stock_location])
         end
 
-        def return_items
+        def return_items(include_received = false)
           customer_return_params[:items].flat_map do |item|
             inventory_units = item_inventory_units(item)
             return_items = inventory_units.map(&:current_or_new_return_item)
-            return_items = prune_received_return_items(return_items)
+            return_items = prune_received_return_items(return_items) unless include_received
             return_items = sort_return_items(return_items)
             return_items.take(item[:quantity].presence || 1)
           end.compact

--- a/lib/spree/wombat/handler/add_customer_return_handler.rb
+++ b/lib/spree/wombat/handler/add_customer_return_handler.rb
@@ -41,7 +41,11 @@ module Spree
             return_items = inventory_units.map(&:current_or_new_return_item)
             return_items = prune_received_return_items(return_items) unless include_received
             return_items = sort_return_items(return_items)
-            return_items.take(item[:quantity].presence || 1)
+
+            quantity = item[:quantity].to_i
+            quantity = 1 if quantity == 0
+            return_items.take(quantity)
+
           end.compact
         end
 
@@ -55,7 +59,7 @@ module Spree
         end
 
         def intended_quantity
-          customer_return_params[:items].map { |i| i[:quantity] }.sum
+          customer_return_params[:items].map { |i| i[:quantity].to_i }.sum
         end
 
         def prune_received_return_items(return_items)

--- a/lib/spree/wombat/handler/add_customer_return_handler.rb
+++ b/lib/spree/wombat/handler/add_customer_return_handler.rb
@@ -43,6 +43,7 @@ module Spree
             inventory_units = item_inventory_units(item)
             return_items = inventory_units.map(&:current_or_new_return_item)
             return_items = prune_received_return_items(return_items) unless include_received
+            return_items.each { |ri| ri.resellable = !!item[:resellable] }
             return_items = sort_return_items(return_items)
 
             quantity = item[:quantity].to_i

--- a/lib/spree/wombat/handler/add_order_handler.rb
+++ b/lib/spree/wombat/handler/add_order_handler.rb
@@ -4,9 +4,37 @@ module Spree
       class AddOrderHandler < OrderHandlerBase
 
         def process
-          order_params = OrderHandlerBase.order_params(@payload[:order])
+          payload = @payload[:order]
+          order_params = OrderHandlerBase.order_params(payload)
+
+
+          adjustment_attrs = []
+
+          shipping_adjustment = nil
+          tax_adjustment = nil
+
+          unless order_params["shipments_attributes"].present?
+            # remove possible shipment adjustment here
+            order_params["adjustments_attributes"].each do |adjustment|
+              adjustment_attrs << adjustment unless adjustment["label"].downcase == "shipping"
+              shipping_adjustment = adjustment if adjustment["label"].downcase == "shipping"
+            end
+          end
+
+          order_params["adjustments_attributes"] = adjustment_attrs if adjustment_attrs.present?
           order = Spree::Core::Importer::Order.import(find_spree_user,order_params)
-          response "Order number #{order.number} was added"
+          order.reload
+
+          number_of_shipments_created = order.shipments.count
+          shipping_cost = payload["totals"]["shipping"]
+          order.shipments.each do |shipment|
+            cost_per_shipment = BigDecimal.new(shipping_cost.to_s) / number_of_shipments_created
+            shipment.update_columns(cost: cost_per_shipment)
+          end
+          order.updater.update_shipment_total
+          order.updater.update_payment_state
+          order.updater.persist_totals
+          response "Order number #{order.number} was added", 200, Base.wombat_objects_for(order.reload)
         end
 
         private

--- a/lib/spree/wombat/handler/add_product_handler.rb
+++ b/lib/spree/wombat/handler/add_product_handler.rb
@@ -31,7 +31,8 @@ module Spree
               response "Product #{@product.sku} added"
             end
           else
-            response "Cannot add the product due to validation errors", 500
+            errors = @product.errors.full_messages.join("\n")
+            response "Product not valid. #{errors}", 500
           end
         end
 

--- a/lib/spree/wombat/handler/add_shipment_handler.rb
+++ b/lib/spree/wombat/handler/add_shipment_handler.rb
@@ -15,6 +15,10 @@ module Spree
 
           external_id = shipment.delete(:id)
 
+          existing_shipment = Spree::Shipment.find_by_number(external_id)
+          return response("Already have a shipment for order #{order_number} associated with shipment number #{external_id}", 500) if existing_shipment
+
+
           address_attributes = shipment.delete(:shipping_address)
           country_iso = address_attributes.delete(:country)
           country = Spree::Country.find_by_iso(country_iso)

--- a/lib/spree/wombat/handler/base.rb
+++ b/lib/spree/wombat/handler/base.rb
@@ -25,8 +25,8 @@ module Spree
           klass.new(message)
         end
 
-        def response(message, code = 200,objects = nil)
-          Spree::Wombat::Responder.new(@request_id, message, code, objects)
+        def response(message, code = 200, objects = nil, exception = nil)
+          Spree::Wombat::Responder.new(@request_id, message, code, objects, exception)
         end
 
         def self.wombat_objects_for(object)

--- a/lib/spree/wombat/handler/base.rb
+++ b/lib/spree/wombat/handler/base.rb
@@ -25,12 +25,56 @@ module Spree
           klass.new(message)
         end
 
-        def response(message, code = 200)
-          Spree::Wombat::Responder.new(@request_id, message, code)
+        def response(message, code = 200,objects = nil)
+          Spree::Wombat::Responder.new(@request_id, message, code, objects)
+        end
+
+        def self.wombat_objects_for(object)
+
+          wombat_objects_hash = {}
+          class_name = object.class.name
+          case class_name
+            when "Spree::Order"
+              if Spree::Wombat::Config[:payload_builder]["Spree::Order"]
+                payload_builder = Spree::Wombat::Config[:payload_builder]["Spree::Order"]
+                wombat_objects_hash[payload_builder[:root]] = generate_order_payload(object.reload)
+                if Spree::Wombat::Config[:push_objects].include? "Spree::Shipment"
+                  payload_builder = Spree::Wombat::Config[:payload_builder]["Spree::Shipment"]
+                  wombat_objects_hash[payload_builder[:root]] = generate_shipments_payload(object.reload.shipments)
+                end
+              end
+            when "Spree::Shipment"
+              if Spree::Wombat::Config[:payload_builder]["Spree::Shipment"]
+                payload_builder = Spree::Wombat::Config[:payload_builder]["Spree::Shipment"]
+                wombat_objects_hash[payload_builder[:root]] = generate_shipments_payload(object.order.reload.shipments)
+                if Spree::Wombat::Config[:push_objects].include? "Spree::Order"
+                  payload_builder = Spree::Wombat::Config[:payload_builder]["Spree::Order"]
+                  wombat_objects_hash[payload_builder[:root]] = generate_order_payload(object.order.reload)
+                end
+              end
+          end
+          wombat_objects_hash
         end
 
         def process
           raise "Please implement the process method in your handler"
+        end
+
+        private
+
+        def self.generate_shipments_payload(shipments)
+          payload_builder = Spree::Wombat::Config[:payload_builder]["Spree::Shipment"]
+          shipments_payload = []
+          shipments.each do |shipment|
+            shipments_payload << JSON.parse(payload_builder[:serializer].constantize.new(shipment, root: false).to_json)
+          end
+          shipments_payload
+        end
+
+        def self.generate_order_payload(order)
+          payload_builder = Spree::Wombat::Config[:payload_builder]["Spree::Order"]
+          order_payload = []
+          order_payload << JSON.parse(payload_builder[:serializer].constantize.new(order, root: false).to_json)
         end
 
       end

--- a/lib/spree/wombat/handler/order_handler_base.rb
+++ b/lib/spree/wombat/handler/order_handler_base.rb
@@ -25,7 +25,7 @@ module Spree
 
           order['line_items_attributes'] = line_items_hash
           order['adjustments_attributes'] = adjustments_attributes_hash
-
+          payments_attributes.map {|payment| payment.delete("id")}
           order['payments_attributes'] = payments_attributes
           order['completed_at'] = placed_on
           order

--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -119,7 +119,7 @@ module Spree
             option_type_values = child_product.delete(:options)
             images = child_product.delete(:images)
             price = child_product[:price]
-            child_product = child_product.slice *Spree::Variant.attribute_names
+            child_product = child_product.slice(*Spree::Variant.attribute_names).except(:id, :product_id)
             child_product[:options] = option_type_values.collect {|k,v| {name: k, value: v} }
             child_product[:price] = price
 

--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -122,7 +122,9 @@ module Spree
             child_product = child_product.slice *Spree::Variant.attribute_names
             child_product[:options] = option_type_values.collect {|k,v| {name: k, value: v} }
             child_product[:price] = price
-            variant = product.variants.find_by_sku(child_product[:sku])
+
+            variant = product.variants.unscoped.find_by_sku(child_product[:sku])
+
             if variant
               variant.update_attributes(child_product)
             else

--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -90,12 +90,12 @@ module Spree
           if taxon
             parent.children << taxon
           else
-            taxon = parent.children.create(name: taxon_name, position: position)
+            taxon = parent.children.create!(name: taxon_name, position: position)
           end
           parent.save
           # store the taxon so we can assign it later
           @taxon_ids << taxon.id
-          add_taxon(taxon, taxon_names, position+1)
+          add_taxon(taxon, taxon_names, position + 1)
         end
 
         def process_images(variant, images)
@@ -125,7 +125,7 @@ module Spree
             if variant
               variant.update_attributes(child_product)
             else
-              variant = product.variants.create({ product: product }.merge(child_product))
+              variant = product.variants.create!({ product: product }.merge(child_product))
             end
             process_images(variant, images)
           end

--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -5,7 +5,7 @@ module Spree
     module Handler
       class ProductHandlerBase < Base
 
-        attr_accessor :params, :children_params, :master_images, :taxon_ids,
+        attr_accessor :params, :children_params, :master_images, :taxons, :taxon_ids,
                       :root_options, :properties
 
         def initialize(message)
@@ -16,12 +16,13 @@ module Spree
           #posible master images
           @master_images = @params.delete(:images)
           @taxon_ids = []
+          @taxons_list = @params.delete(:taxons)
         end
 
         def root_product_attrs
           permalink = @params.delete(:permalink)
           shipping_category_name = @params.delete(:shipping_category)
-          process_taxons(@params.delete(:taxons))
+          process_taxons(@taxons_list)
           @root_options = @params.delete(:options)
           @properties = @params.delete(:properties)
 
@@ -33,7 +34,7 @@ module Spree
           sku = @params[:sku]
           @params = @params.slice *Spree::Product.attribute_names
           @params.delete(:id) # Reject ID as it should be set by database or else it could convert to 0 in postgresql.
-          @params[:taxon_ids] = Spree::Taxon.where(id: @taxon_ids).leaves.pluck(:id)
+          @params[:taxon_ids] = Spree::Taxon.where(id: @taxon_ids).leaves.pluck(:id) unless @taxons_list.nil?
           @params[:price] = price
           @params[:sku] = sku
           @params

--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -5,7 +5,7 @@ module Spree
     module Handler
       class ProductHandlerBase < Base
 
-        attr_accessor :params, :children_params, :master_images, :taxons, :taxon_ids,
+        attr_accessor :params, :children_params, :master_images, :taxons_list, :taxon_ids,
                       :root_options, :properties
 
         def initialize(message)

--- a/lib/spree/wombat/handler/set_price_handler.rb
+++ b/lib/spree/wombat/handler/set_price_handler.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Wombat
+    module Handler
+      class SetPriceHandler < Base
+        def process
+          sku = @payload[:price].delete(:product_id)
+          variant = Spree::Variant.find_by_sku(sku)
+          return response("Product with SKU #{sku} was not found", 500) unless variant
+
+          updatable_columns = @payload[:price].slice *Spree::Variant.attribute_names.select{|n| n =~ /price/i }.concat(["price"])
+          return response("Missing price information", 500) unless updatable_columns[:price]
+
+          current_price = variant.price
+          current_currency = variant.currency
+
+          Spree::Variant.transaction do
+            variant.update_attributes!(updatable_columns)
+          end
+
+          return response("Set price for #{sku} from #{current_price} #{current_currency} to #{variant.reload.price} #{variant.reload.currency}")
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/wombat/handler/update_product_handler.rb
+++ b/lib/spree/wombat/handler/update_product_handler.rb
@@ -9,7 +9,6 @@ module Spree
           id = params.delete(:id)
           product = Spree::Variant.where(is_master: true, sku: params[:sku]).first.product
           return response("Cannot find product with SKU #{params[:sku]}!", 500) unless product
-
           # Disable the after_touch callback on taxons
           Spree::Product.skip_callback(:touch, :after, :touch_taxons)
 
@@ -44,7 +43,7 @@ module Spree
 
           product
         end
-        
+
       end
     end
   end

--- a/lib/spree/wombat/handler/update_product_handler.rb
+++ b/lib/spree/wombat/handler/update_product_handler.rb
@@ -7,8 +7,14 @@ module Spree
 
         def process
           id = params.delete(:id)
-          product = Spree::Variant.where(is_master: true, sku: params[:sku]).first.product
-          return response("Cannot find product with SKU #{params[:sku]}!", 500) unless product
+          variant = Variant.where(is_master: true, sku: params[:sku]).first
+
+          if variant.nil? || variant.product.nil?
+            return response("Cannot find product with SKU #{params[:sku]}!", 500)
+          end
+
+          product = variant.product
+
           # Disable the after_touch callback on taxons
           Spree::Product.skip_callback(:touch, :after, :touch_taxons)
 

--- a/lib/spree/wombat/handler/update_product_handler.rb
+++ b/lib/spree/wombat/handler/update_product_handler.rb
@@ -30,9 +30,9 @@ module Spree
               response "Product #{@product.sku} updated"
             end
           else
-            response "Cannot update the product due to validation errors", 500
+            errors = @product.errors.full_messages.join("\n")
+            response "Product not valid. #{errors}", 500
           end
-
         end
 
         # the Spree::Product and Spree::Variant master

--- a/lib/spree/wombat/handler/update_shipment_handler.rb
+++ b/lib/spree/wombat/handler/update_shipment_handler.rb
@@ -119,7 +119,11 @@ module Spree
           shipment.order.updater.update_shipment_state
           shipment.order.updater.update
 
-          return response("Updated shipment #{shipment_number}")
+          #make sure we set the provided cost, since the order updater is refreshing the shipment rates
+          # based on the shipping method.
+          shipment.update_columns(cost: shipment_attributes[:cost]) if shipment_attributes[:cost].present?
+
+          return response("Updated shipment #{shipment_number}", 200, Base.wombat_objects_for(shipment))
         end
 
       end

--- a/lib/spree/wombat/responder.rb
+++ b/lib/spree/wombat/responder.rb
@@ -3,14 +3,22 @@ require "active_model/serializer_support"
 module Spree
   module Wombat
     class Responder
-      include ActiveModel::SerializerSupport
-      attr_accessor :request_id, :summary, :code, :backtrace, :objects
+      class ErroredResponse < StandardError; end
 
-      def initialize(request_id, summary, code=200, objects=nil)
+      include ActiveModel::SerializerSupport
+      attr_accessor :request_id, :summary, :code, :objects, :exception
+
+      def initialize(request_id, summary, code=200, objects=nil, exception=nil)
+        if code.to_i.between?(500,599) && exception.nil?
+          exception = ErroredResponse.new(summary)
+          exception.set_backtrace(caller)
+        end
+
         self.request_id = request_id
         self.summary = summary
         self.code = code
         self.objects = objects
+        self.exception = exception
       end
 
     end

--- a/lib/spree/wombat/responder.rb
+++ b/lib/spree/wombat/responder.rb
@@ -1,11 +1,10 @@
-require "active_model/serializer_support"
-
 module Spree
   module Wombat
     class Responder
       class ErroredResponse < StandardError; end
 
-      include ActiveModel::SerializerSupport
+      alias read_attribute_for_serialization send
+
       attr_accessor :request_id, :summary, :code, :objects, :exception
 
       def initialize(request_id, summary, code=200, objects=nil, exception=nil)

--- a/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
-shared_examples "receives the return items" do
-
+shared_examples "receives the return items" do |message=/Customer return \d+ was added/|
   it "succeeds" do
-    expect(responder.summary).to match /Customer return \d+ was added/
+    expect(responder.summary).to match message
     expect(responder.code).to eql 200
   end
 
@@ -28,7 +27,11 @@ shared_examples "receives the return items" do
 
   it "attempts to accept all of the return items" do
     accept_count = 0
-    Spree::ReturnItem.any_instance.stub(:attempt_accept) { accept_count += 1 }
+    original_method = Spree::ReturnItem.instance_method(:attempt_accept)
+    Spree::ReturnItem.any_instance.stub(:attempt_accept) do |return_item|
+      accept_count += 1
+      original_method.bind(return_item).call
+    end
     subject
     expect(accept_count).to eq 3
   end
@@ -149,6 +152,15 @@ module Spree
               end
               it_behaves_like "receives the return items"
               it_behaves_like "does not attempt to refund the customer"
+            end
+
+            context "the customer return raises an IncompleteReimbursement error" do
+              before do
+                expect_any_instance_of(Spree::Reimbursement).to(
+                  receive(:perform!).and_raise(Spree::Reimbursement::IncompleteReimbursement)
+                )
+              end
+              it_behaves_like "receives the return items", /Customer return \d+ processed but not fully reimbursed/
             end
           end
 

--- a/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
@@ -243,7 +243,9 @@ module Spree
           end
 
           context "there is a mix of created and new return items" do
-            let(:return_item) { order.inventory_units.last.current_or_new_return_item.tap(&:save) }
+            let(:return_item) do
+              order.inventory_units.order(:id).last.current_or_new_return_item.tap(&:save)
+            end
 
             before do
               rma.return_items << return_item

--- a/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
@@ -112,13 +112,13 @@ module Spree
                 items: [
                   {
                     sku: variant_1.sku,
-                    quantity: 1,
+                    quantity: "1",
                     product_status: "GOOD",
                     order_number: order.number,
                   },
                   {
                     sku: variant_2.sku,
-                    quantity: 2,
+                    quantity: "2",
                     product_status: "DAMAGED",
                     order_number: order.number,
                   }

--- a/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
@@ -116,13 +116,13 @@ module Spree
                   {
                     sku: variant_1.sku,
                     quantity: "1",
-                    product_status: "GOOD",
+                    resellable: true,
                     order_number: order.number,
                   },
                   {
                     sku: variant_2.sku,
                     quantity: "2",
-                    product_status: "DAMAGED",
+                    resellable: false,
                     order_number: order.number,
                   }
                 ]
@@ -136,6 +136,11 @@ module Spree
 
           it "has the correct request_id" do
             expect(responder.request_id).to eql message["request_id"]
+          end
+
+          context "resellable" do
+            it { expect { subject }.to change { Spree::ReturnItem.count }.by(3) }
+            it { subject; expect(Spree::ReturnItem.order(:created_at).last(3).map(&:resellable)).to eq [true, false, false] }
           end
 
           context "all return items are for the rma" do

--- a/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/add_customer_return_handler_spec.rb
@@ -157,7 +157,7 @@ module Spree
             context "the customer return raises an IncompleteReimbursement error" do
               before do
                 expect_any_instance_of(Spree::Reimbursement).to(
-                  receive(:perform!).and_raise(Spree::Reimbursement::IncompleteReimbursement)
+                  receive(:perform!).and_raise(Spree::Reimbursement::IncompleteReimbursementError)
                 )
               end
               it_behaves_like "receives the return items", /Customer return \d+ processed but not fully reimbursed/

--- a/spec/lib/spree/wombat/handler/add_order_handler_shopify_json_spec.rb
+++ b/spec/lib/spree/wombat/handler/add_order_handler_shopify_json_spec.rb
@@ -1,0 +1,174 @@
+require 'spec_helper'
+
+module Spree
+  module Wombat
+    describe Handler::AddOrderHandler do
+      let!(:country) { create(:country) }
+      let!(:state) { country.states.first || create(:state, :country => country) }
+
+      let!(:user) do
+        user = Spree.user_class.new(:email => "spree@example.com")
+        user.generate_spree_api_key!
+        user
+      end
+
+      let!(:variant) { create(:variant, :id => 73) }
+      let!(:payment_method) { create(:credit_card_payment_method, name: 'bogus') }
+
+      context "#process" do
+        context "with shopify order data" do
+          let!(:message) do
+            msg = ::Hub::Samples::Order.request
+            msg["order"] = {
+              "id"=> "schoftech_1018",
+              "shopify_id"=> "342660281",
+              "source"=> "schoftech.myshopify.com",
+              "channel"=> "schoftech.myshopify.com",
+              "status"=> "complete",
+              "email"=> "sameer@spreecommerce.com",
+              "currency"=> "USD",
+              "placed_on"=> "2014-10-01T13=>38=>28Z",
+              "totals"=> {
+                "item"=> 38,
+                "tax"=> 0,
+                "shipping"=> 10,
+                "payment"=> 49.9,
+                "order"=> 49.9,
+                "adjustment"=> 11.9
+              },
+              "line_items"=> [
+                {
+                  "id"=> 235,
+                  "product_id"=> "SPR-00001-Variant",
+                  "name"=> "Spree Baseball Jersey",
+                  "quantity"=> 2,
+                  "price"=> 19
+                }
+              ],
+              "adjustments"=> [
+                {
+                  "name"=> "discount",
+                  "value"=> 11.9
+                },
+                {
+                  "name"=> "tax",
+                  "value"=> 0
+                },
+                {
+                  "name"=> "shipping",
+                  "value"=> 10
+                }
+              ],
+              "shipping_address"=> {
+                "firstname"=> "Sameer",
+                "lastname"=> "Gulati",
+                "address1"=> "3627 Ordway Street NW",
+                "address2"=> "",
+                "zipcode"=> "20814",
+                "city"=> "Bethesda",
+                "state"=> "MD",
+                "country"=> "US",
+                "phone"=> "4084552962"
+              },
+              "billing_address"=> {
+                "firstname"=> "Sameer",
+                "lastname"=> "Gulati",
+                "address1"=> "3627 Ordway Street NW",
+                "address2"=> "",
+                "zipcode"=> "20814",
+                "city"=> "Bethesda",
+                "state"=> "MD",
+                "country"=> "US",
+                "phone"=> "4084552962"
+              },
+              "payments"=> [
+                {
+                  "id"=> 45,
+                  "number"=> "AKJSKJHD",
+                  "status"=> "completed",
+                  "amount"=> 49.9,
+                  "payment_method"=> "bogus"
+                }
+              ],
+              "updated_at"=> "2014-10-01T13=>40=>55Z",
+              "token"=> "36a7b988b2e068e5",
+              "shipping_instructions"=> nil
+            }
+            msg
+          end
+          let(:handler) { Handler::AddOrderHandler.new(message.to_json) }
+
+          let(:line_item) { message['order']['line_items'].first }
+
+          before { create(:variant, sku: line_item['product_id']) }
+
+          it "imports a new order in the storefront" do
+            expect{handler.process}.to change{Spree::Order.count}.by(1)
+          end
+
+          it "sets number from order payload id" do
+            handler.process
+            expect(Order.last.number).to eq message['order']['id']
+          end
+
+          it "creates line items properly" do
+            handler.process
+            expect(LineItem.last.variant.sku).to eq line_item['product_id']
+          end
+
+          it "returns a Hub::Responder" do
+            responder = handler.process
+            expect(responder.class.name).to eql "Spree::Wombat::Responder"
+            expect(responder.request_id).to eql message["request_id"]
+            expect(responder.summary).to match /Order number schoftech_1018 was added/
+          end
+
+          it "adding the payment" do
+            expect{handler.process}.to change{Spree::Payment.count}.by(1)
+          end
+
+          it "generating proposed shipments" do
+            expect{handler.process}.to change{Spree::Shipment.count}.by(1)
+          end
+
+          context "payment" do
+            before do
+              handler.process
+              order = Spree::Order.find_by_number("schoftech_1018")
+              @payment = order.payments.first
+            end
+
+            it "amount is set correctly" do
+              expect(@payment.amount).to eql 49.9
+            end
+
+          end
+
+          context "shipments" do
+            before do
+              handler.process
+              order = Spree::Order.find_by_number("schoftech_1018")
+              @shipment = order.shipments.first
+            end
+
+            it "cost is set correctly" do
+              expect(@shipment.cost).to eql 10
+            end
+          end
+
+          context "adjustments" do
+            before do
+              handler.process
+              @order = Spree::Order.find_by_number("schoftech_1018")
+            end
+
+            it "shipment total" do
+              expect(@order.shipment_total).to eql 10.0
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/spree/wombat/handler/add_product_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/add_product_handler_spec.rb
@@ -214,7 +214,7 @@ module Spree
         it "will assign the option types to the product" do
           handler.process_option_types(product,["color", "size"])
           expect(product.option_types.count).to eql 2
-          expect(product.option_types.collect(&:name)).to eql ["color", "size"]
+          expect(product.option_types.collect(&:name)).to match_array ["color", "size"]
         end
       end
 

--- a/spec/lib/spree/wombat/handler/set_price_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/set_price_handler_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+module Spree
+  module Wombat
+    describe Handler::SetPriceHandler do
+      let(:message) {::Hub::Samples::Price.request}
+      let(:handler) { Handler::SetPriceHandler.new(message.to_json) }
+
+      describe "process" do
+        context "with stock item present" do
+          let!(:variant) { create(:variant, :sku => 'SPREE-T-SHIRT', price: 12.0, cost_price: 5.0) }
+
+          context "and the stock location name is equal to location in the message" do
+            it "will set the price to the supplied amount" do
+              expect{handler.process}.to change{variant.reload.price.to_f}.from(12.0).to(12.95)
+            end
+
+            it "will set the cost_price to the supplied amount" do
+              expect{handler.process}.to change{variant.reload.cost_price.to_f}.from(5.0).to(6.25)
+            end
+
+            it "returns a Hub::Responder with a proper message" do
+              responder = handler.process
+              expect(responder.summary).to eql "Set price for SPREE-T-SHIRT from 12.0 USD to 12.95 USD"
+              expect(responder.code).to eql 200
+            end
+          end
+        end
+
+        context "with variant not present" do
+          it "returns a Hub::Responder with 500 status" do
+            responder = handler.process
+            expect(responder.summary).to eql "Product with SKU SPREE-T-SHIRT was not found"
+            expect(responder.code).to eql 500
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
@@ -14,6 +14,34 @@ module Spree
         expect(response.summary).to match "Cannot find product with SKU"
       end
 
+      it "doesnt create duplicated variant" do
+        message = {
+          product: {
+            name: 'rails',
+            sku: 'rails',
+            shipping_category: 'default',
+            price: 30,
+            variants: [
+              {
+                sku: 'not rails',
+                deleted_at: Time.now,
+                options: []
+              }
+            ]
+          }
+        }
+
+        expect {
+          handler = Handler::AddProductHandler.new message.to_json
+          handler.process
+        }.to change { Variant.unscoped.count }.by(2)
+
+        expect {
+          handler = described_class.new message.to_json
+          response = handler.process
+        }.not_to change { Variant.unscoped.count }
+      end
+
       context "#process" do
         let!(:message) do
           hsh = ::Hub::Samples::Product.request

--- a/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
@@ -16,7 +16,11 @@ module Spree
           hsh
         end
 
-        let!(:variant) { create(:master_variant, sku: message["product"]["sku"])}
+        let!(:variant) do
+          p = create(:product)
+          p.master.update_attributes(sku: message["product"]["sku"])
+          p.master
+        end
 
         let(:handler) { Handler::UpdateProductHandler.new(message.to_json) }
 

--- a/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
@@ -46,6 +46,58 @@ module Spree
           end
         end
 
+        context "and regarding taxons" do
+          let(:message_without_taxons) do
+            message["product"].delete("taxons")
+            message
+          end
+
+          let(:message_with_empty_taxons) do
+            message["product"]["taxons"] = []
+            message
+          end
+
+          let(:message_with_different_taxons) do
+            message["product"]["taxons"] = [["Categories", "Scuba Gear"], ["Brands", "Scuba"]]
+            message
+          end
+
+          let(:handler_without_taxons) { Handler::UpdateProductHandler.new(message_without_taxons.to_json) }
+          let(:handler_with_empty_taxons) { Handler::UpdateProductHandler.new(message_with_empty_taxons.to_json) }
+          let(:handler_with_different_taxons) { Handler::UpdateProductHandler.new(message_with_different_taxons.to_json) }
+
+          let(:product) { Spree::Variant.find_by_sku(message["product"]["sku"]).product }
+
+          before do
+            handler.process
+          end
+
+          it "updates a product with taxons" do
+            expect(product.taxons.size).to eq 3
+          end
+
+          it "updates a product without taxons" do
+            expect(product.taxons.size).to eq 3
+
+            handler_without_taxons.process
+            expect(product.taxons.size).to eq 3
+          end
+
+          it "updates a product with empty taxons" do
+            expect(product.taxons.size).to eq 3
+
+            handler_with_empty_taxons.process
+            expect(product.taxons.size).to eq 0
+          end
+
+          it "updates a product with different taxons" do
+            expect(product.taxons.size).to eq 3
+
+            handler_with_different_taxons.process
+            expect(product.taxons.size).to eq 2
+          end
+        end
+
 
         context "response" do
           let(:responder) { handler.process }

--- a/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
+++ b/spec/lib/spree/wombat/handler/update_product_handler_spec.rb
@@ -3,10 +3,15 @@ require 'spec_helper'
 module Spree
   module Wombat
     describe Handler::UpdateProductHandler do
-
       before do
         img_fixture = File.open(File.expand_path('../../../../../fixtures/thinking-cat.jpg', __FILE__))
         URI.stub(:parse).and_return img_fixture
+      end
+
+      it "respond properly if product not found" do
+        handler = described_class.new Hub::Samples::Product.request.to_json
+        response = handler.process
+        expect(response.summary).to match "Cannot find product with SKU"
       end
 
       context "#process" do

--- a/spec/lib/spree/wombat/responder_spec.rb
+++ b/spec/lib/spree/wombat/responder_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+module Spree
+  module Wombat
+    describe Responder do
+
+      describe '#initialize' do
+        subject do
+          Responder.new(*params)
+        end
+
+        let(:params) { [request_id, summary, code, objects, exception] }
+
+        let(:request_id) { 'some id' }
+        let(:summary) { 'some summary' }
+        let(:code) { 200 }
+        let(:objects) { nil }
+        let(:exception) { nil }
+
+        context 'with a 5xx error code and no exception' do
+          let(:code) { 500 }
+
+          it 'builds an exception from the summary' do
+            expect(subject.exception).to be_a Responder::ErroredResponse
+            expect(subject.exception.message).to eq summary
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/serializers/spree/wombat/adjustment_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/adjustment_serializer_spec.rb
@@ -4,7 +4,7 @@ module Spree
   module Wombat
     describe AdjustmentSerializer do
 
-      let(:adjustment) { create(:adjustment) }
+      let(:adjustment) { create(:adjustment, order: create(:order)) }
       let(:serialized_adjustment) { AdjustmentSerializer.new(adjustment, root: false).to_json }
 
       it "serializes the value as float" do

--- a/spec/serializers/spree/wombat/order_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/order_serializer_spec.rb
@@ -64,14 +64,27 @@ module Spree
               create(:adjustment, adjustable: order, source_type: 'Spree::PromotionAction', amount: -10)
               create(:adjustment, adjustable: order.line_items.first, source_type: 'Spree::PromotionAction', amount: -10)
               create(:adjustment, adjustable: order.shipments.first, source_type: 'Spree::PromotionAction', amount: -10)
+              #create(:adjustment, adjustable: order, source_type: nil, source_id: nil, amount: -10, label: 'Manual discount')
               order.update_totals
             end
 
             it "discount matches order promo total value" do
               discount_hash = serialized_order["adjustments"].select { |a| a["name"] == "discount" }.first
-              expect(discount_hash["value"]).to eq order.adjustment_total.to_f
+              expect(discount_hash["value"]).to eq -30.0
             end
           end
+
+          context 'manual tax from import' do
+            before do
+              create(:adjustment, adjustable: order, source_type: nil, source_id: nil, amount: 1.14, label: 'Tax')
+              order.update_totals
+            end
+
+            it "tax_total matches the manual value" do
+              expect(serialized_order["totals"]["tax"]).to eql 1.14
+            end
+          end
+
         end
       end
     end

--- a/spec/serializers/spree/wombat/order_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/order_serializer_spec.rb
@@ -86,6 +86,16 @@ module Spree
           end
 
         end
+
+        context "promotions" do
+          let!(:promotion) { create(:promotion) }
+          before { order.promotions << promotion }
+
+          it "includes promotions" do
+            promo_json = Spree::Wombat::PromotionSerializer.new(promotion, root: false).as_json.stringify_keys
+            expect(serialized_order['promotions']).to eq [promo_json]
+          end
+        end
       end
     end
   end

--- a/spec/serializers/spree/wombat/order_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/order_serializer_spec.rb
@@ -61,9 +61,9 @@ module Spree
 
           context 'discount' do
             before do
-              create(:adjustment, adjustable: order, source_type: 'Spree::PromotionAction', amount: -10)
-              create(:adjustment, adjustable: order.line_items.first, source_type: 'Spree::PromotionAction', amount: -10)
-              create(:adjustment, adjustable: order.shipments.first, source_type: 'Spree::PromotionAction', amount: -10)
+              create(:adjustment, adjustable: order, source_type: 'Spree::PromotionAction', amount: -10, order: order)
+              create(:adjustment, adjustable: order.line_items.first, source_type: 'Spree::PromotionAction', amount: -10, order: order)
+              create(:adjustment, adjustable: order.shipments.first, source_type: 'Spree::PromotionAction', amount: -10, order: order)
               #create(:adjustment, adjustable: order, source_type: nil, source_id: nil, amount: -10, label: 'Manual discount')
               order.update_totals
             end
@@ -76,7 +76,7 @@ module Spree
 
           context 'manual tax from import' do
             before do
-              create(:adjustment, adjustable: order, source_type: nil, source_id: nil, amount: 1.14, label: 'Tax')
+              create(:adjustment, adjustable: order, source_type: nil, source_id: nil, amount: 1.14, label: 'Tax', order: order)
               order.update_totals
             end
 

--- a/spec/serializers/spree/wombat/payment_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/payment_serializer_spec.rb
@@ -6,7 +6,7 @@ module Spree
       let(:payment) do
         Spree::Payment.new do |p|
           p.amount = 55
-          p.identifier = "0number"
+          p.number = "0number"
           p.state = "completed"
           p.payment_method = Spree::PaymentMethod.new(name: "P Method")
         end
@@ -17,7 +17,7 @@ module Spree
       it "serializes attributes" do
         expect(JSON.parse(subject)["amount"]).to eql payment.amount.to_f
         expect(JSON.parse(subject)["payment_method"]).to eql payment.payment_method.name
-        expect(JSON.parse(subject)["number"]).to eql payment.identifier
+        expect(JSON.parse(subject)["number"]).to eql payment.number
         expect(JSON.parse(subject)["status"]).to eql payment.state
       end
 

--- a/spec/serializers/spree/wombat/product_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/product_serializer_spec.rb
@@ -94,7 +94,7 @@ module Spree
             ActionController::Base.asset_host = "http://myapp.dev"
             image = File.open(File.expand_path('../../../../fixtures/thinking-cat.jpg', __FILE__))
             3.times.each_with_index do |i|
-              product.images.create!(attachment: image, position: i, alt: "variant image #{i}")
+              product.images.create!(attachment: image, alt: "variant image #{i}")
             end
           end
 
@@ -103,7 +103,7 @@ module Spree
             dimension_hash = {"height" => 490, "width" => 489}
             3.times.each_with_index do |i|
               expect(serialized_product["images"][i]["url"]).to match /http:\/\/myapp.dev\/spree\/products\/\d*\/original\/thinking-cat.jpg\z/
-              expect(serialized_product["images"][i]["position"]).to eql i
+              expect(serialized_product["images"][i]["position"]).to eql (i + 1)
               expect(serialized_product["images"][i]["title"]).to eql "variant image #{i}"
               expect(serialized_product["images"][i]["type"]).to eql "original"
               expect(serialized_product["images"][i]["dimensions"]).to eql dimension_hash

--- a/spec/serializers/spree/wombat/product_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/product_serializer_spec.rb
@@ -77,7 +77,7 @@ module Spree
         context "options" do
           let(:product) {create(:product_with_option_types)}
           it "returns an array with the option_types" do
-            expect(serialized_product["options"]).to eql ["foo-size"]
+            expect(serialized_product["options"]).to eql ["foo-size-#{product.option_types.first.id}"]
           end
         end
 

--- a/spec/serializers/spree/wombat/product_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/product_serializer_spec.rb
@@ -75,9 +75,10 @@ module Spree
         end
 
         context "options" do
-          let(:product) {create(:product_with_option_types)}
+          let(:product) { create(:product_with_option_types) }
           it "returns an array with the option_types" do
-            expect(serialized_product["options"]).to eql ["foo-size-#{product.option_types.first.id}"]
+            expect(serialized_product["options"].first).to match "foo-size-"
+            expect(serialized_product["options"].size).to eq 1
           end
         end
 
@@ -118,8 +119,8 @@ module Spree
         end
 
         context "with variants" do
-          let!(:product) {create(:product_with_option_types)}
-          let!(:variant) { create(:variant, :product => product) }
+          let!(:product) { create(:product_with_option_types) }
+          let!(:variant) { create(:variant, product: product) }
           it "serialized the variant and master as nested objects" do
             product.reload
             expect(serialized_product["variants"].count).to eql 1

--- a/spec/serializers/spree/wombat/product_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/product_serializer_spec.rb
@@ -122,7 +122,7 @@ module Spree
           let!(:variant) { create(:variant, :product => product) }
           it "serialized the variant and master as nested objects" do
             product.reload
-            expect(serialized_product["variants"].count).to eql 2
+            expect(serialized_product["variants"].count).to eql 1
           end
         end
       end

--- a/spec/serializers/spree/wombat/promotion_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/promotion_serializer_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module Spree
+  module Wombat
+    describe PromotionSerializer, type: :serializer do
+      let(:promotion) { Spree::Promotion.new(name: "Promo", code: "pro") }
+      let(:serialized) { JSON.parse(PromotionSerializer.new(promotion, root: false).to_json) }
+
+      before { promotion.build_promotion_category(name: "Category", code: "cat") }
+
+      it { expect(serialized['code']).to eq 'pro' }
+      it { expect(serialized['name']).to eq 'Promo' }
+      it { expect(serialized['category_code']).to eq 'cat' }
+      it { expect(serialized['category_name']).to eq 'Category' }
+
+    end
+  end
+end

--- a/spec/serializers/spree/wombat/responder_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/responder_serializer_spec.rb
@@ -12,8 +12,9 @@ module Spree
       end
 
       it "serializes a backtrace when present" do
-        responder.backtrace = "Big fat error"
-        json_response = "{\"request_id\":\"12355\",\"summary\":\"Order abc124 was added\",\"backtrace\":\"Big fat error\"}"
+        responder.exception = StandardError.new
+        responder.exception.set_backtrace(['some backtrace'])
+        json_response = "{\"request_id\":\"12355\",\"summary\":\"Order abc124 was added\",\"backtrace\":\"[\\\"some backtrace\\\"]\"}"
         expect(ResponderSerializer.new(responder, root: false).to_json).to eql json_response
       end
 

--- a/spec/serializers/spree/wombat/return_item_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/return_item_serializer_spec.rb
@@ -47,6 +47,47 @@ module Spree
           return_item.additional_tax_total = 5.0.to_d
           expect(serialized_return_item[:additional_tax_total]).to eq "5.0"
         end
+
+        it "sets the id" do
+          return_item.save!
+          expect(serialized_return_item[:id]).to eq return_item.id
+        end
+
+        it 'sets the order number' do
+          return_item.save!
+          expect(serialized_return_item[:order_number]).to eq return_item.inventory_unit.order.number
+        end
+
+        it 'sets the created_at' do
+          return_item.save!
+          expect(serialized_return_item[:created_at]).to eq return_item.created_at.as_json
+        end
+
+        context 'is reimbursed' do
+          it 'sets reimbursed to true' do
+            return_item.build_reimbursement
+            expect(serialized_return_item[:reimbursed]).to eq true
+          end
+
+          it 'sets reimbursed_at' do
+            return_item.create_reimbursement
+            expect(serialized_return_item[:reimbursed_at]).to eq return_item.reimbursement.created_at.as_json
+          end
+        end
+
+        context 'is not reimbursed' do
+          it 'sets reimbursed to false' do
+            expect(serialized_return_item[:reimbursed]).to eq false
+          end
+
+          it 'does not set reimbursed_at' do
+            expect(serialized_return_item[:reimbursed_at]).to eq nil
+          end
+        end
+
+        it "sets the order's store as the store code" do
+          expect(serialized_return_item[:store]).to eq return_item.inventory_unit.order.store.code
+        end
       end
     end
   end

--- a/spec/serializers/spree/wombat/variant_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/variant_serializer_spec.rb
@@ -53,7 +53,7 @@ module Spree
             ActionController::Base.asset_host = "http://myapp.dev"
             image = File.open(File.expand_path('../../../../fixtures/thinking-cat.jpg', __FILE__))
             3.times.each_with_index do |i|
-              variant.images.create!(attachment: image, position: i, alt: "variant image #{i}")
+              variant.images.create!(attachment: image, alt: "variant image #{i}")
             end
           end
 
@@ -62,7 +62,7 @@ module Spree
             dimension_hash = {"height" => 490, "width" => 489}
             3.times.each_with_index do |i|
               expect(serialized_variant["images"][i]["url"]).to match /http:\/\/myapp.dev\/spree\/products\/\d*\/original\/thinking-cat.jpg\z/
-              expect(serialized_variant["images"][i]["position"]).to eql i
+              expect(serialized_variant["images"][i]["position"]).to eql (i + 1)
               expect(serialized_variant["images"][i]["title"]).to eql "variant image #{i}"
               expect(serialized_variant["images"][i]["type"]).to eql "original"
               expect(serialized_variant["images"][i]["dimensions"]).to eql dimension_hash

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require 'rspec/autorun'
 require 'database_cleaner'
 require 'ffaker'
 require 'hub/samples'
+require 'timecop'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'simplecov'
 SimpleCov.start do
-
   add_group 'Models', '/app/models/'
   add_group 'Controllers', '/app/controllers/'
   add_group 'Serializers', '/app/serializers/'
@@ -32,40 +31,38 @@ require 'hub/samples'
 # in spec/support/ and its subdirectories.
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
+require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
-require 'spree/testing_support/controller_requests'
 require 'active_model/serializer'
 
 RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]
   config.color = true
   config.infer_spec_type_from_file_location!
-  
+
   config.include FactoryGirl::Syntax::Methods
-  config.include Spree::TestingSupport::Preferences, :type => :controller
-  config.include Spree::TestingSupport::ControllerRequests, :type => :controller
+  config.include Spree::TestingSupport::Preferences, type: :controller
+  config.include Spree::TestingSupport::ControllerRequests, type: :controller
 
   config.fail_fast = ENV['FAIL_FAST'] || false
 
   config.use_transactional_fixtures = false
 
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :deletion
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
+  config.after do
     DatabaseCleaner.clean
   end
 
   config.before do
     HTTParty.stub :post
     Spree::Wombat::Config[:connection_token] = "abc1233"
+
+    DatabaseCleaner.start
+  end
+
+  config.before :suite do
+    DatabaseCleaner.strategy = :deletion
+    DatabaseCleaner.clean_with :truncation
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :deletion
     DatabaseCleaner.clean_with :truncation
   end
+
+  config.mock_with :rspec do |mocks|
+    mocks.yield_receiver_to_any_instance_implementation_blocks = true
+  end
 end
 
 class Spree::Wombat::Handler::MyCustomHandler < Spree::Wombat::Handler::Base

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = '2.2.0'
 
-  gem.add_dependency 'spree_core', '2.4.0.rc4'
+  gem.add_dependency 'spree_core', '~> 2.4.0.rc4'
   gem.add_dependency 'active_model_serializers', '0.9.0.alpha1'
   gem.add_dependency 'httparty'
 

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = '2.2.0'
 
   gem.add_dependency 'spree_core', '~> 3.1.0.beta'
-  gem.add_dependency 'active_model_serializers', '0.9.0.alpha1'
+  gem.add_dependency 'active_model_serializers', '~> 0.8.3'
   gem.add_dependency 'httparty'
 
   gem.add_development_dependency 'capybara', '~> 2.1'

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -18,13 +18,16 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'httparty'
 
   gem.add_development_dependency 'capybara', '~> 2.1'
-  gem.add_development_dependency 'coffee-rails'
+  gem.add_development_dependency 'coffee-rails', '~> 4.0.0'
   gem.add_development_dependency 'database_cleaner', '~> 1.3.0' # 1.4.0 is broken https://github.com/DatabaseCleaner/database_cleaner/issues/317
   gem.add_development_dependency 'factory_girl', '~> 4.4'
   gem.add_development_dependency 'ffaker'
+  gem.add_development_dependency 'mysql2'
+  gem.add_development_dependency 'pg'
   gem.add_development_dependency 'rspec-rails',  '~> 2.13'
-  gem.add_development_dependency 'sass-rails'
+  gem.add_development_dependency 'sass-rails', '~> 4.0.0'
   gem.add_development_dependency 'selenium-webdriver'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'sqlite3'
+  gem.add_development_dependency 'timecop'
 end

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = '2.2.0'
 
-  gem.add_dependency 'spree_core', '~> 3.0.0.beta'
+  gem.add_dependency 'spree_core', '~> 3.1.0.beta'
   gem.add_dependency 'active_model_serializers', '0.9.0.alpha1'
   gem.add_dependency 'httparty'
 

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = '2.2.0'
 
-  gem.add_dependency 'spree_core', '~> 2.4.0.rc4'
+  gem.add_dependency 'spree_core', '~> 3.0.0.beta'
   gem.add_dependency 'active_model_serializers', '0.9.0.alpha1'
   gem.add_dependency 'httparty'
 

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'capybara', '~> 2.1'
   gem.add_development_dependency 'coffee-rails'
-  gem.add_development_dependency 'database_cleaner'
+  gem.add_development_dependency 'database_cleaner', '~> 1.3.0' # 1.4.0 is broken https://github.com/DatabaseCleaner/database_cleaner/issues/317
   gem.add_development_dependency 'factory_girl', '~> 4.4'
   gem.add_development_dependency 'ffaker'
   gem.add_development_dependency 'rspec-rails',  '~> 2.13'

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = '2.2.0'
 
-  gem.add_dependency 'spree_core', '2.4.0.rc3'
+  gem.add_dependency 'spree_core', '2.4.0.rc4'
   gem.add_dependency 'active_model_serializers', '0.9.0.alpha1'
   gem.add_dependency 'httparty'
 

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = '2.2.0'
 
-  gem.add_dependency 'spree_core', '2.4.0.beta'
+  gem.add_dependency 'spree_core', '2.4.0.rc3'
   gem.add_dependency 'active_model_serializers', '0.9.0.alpha1'
   gem.add_dependency 'httparty'
 


### PR DESCRIPTION
At present, `spree_wombat` depends on the 0.9.x branch of `active_model_serializers`. Development along this branch appears [to be defunct](https://github.com/rails-api/active_model_serializers#maintenance-please-read), with the rails-api team opting to work on an 0.10.x branch based off the 0.8.x branch. Phew, confusing!

Given the roadmap for AMS, I propose that it makes more sense to depend on the 0.8.x branch than the 0.9.x branch. This PR changes the version of `active_model_serializers` on which `spree_wombat` depends, and small changes to the serializers to keep the test suite green. My PR is targets the `2-4-stable` branch—please let me know if this maps to your contribution guidelines.

Looking forward to comments/feedback. Thanks!