### PR TITLE
Changes Version of 'active_model_serializers' Dependency

### DIFF
--- a/app/serializers/spree/wombat/address_serializer.rb
+++ b/app/serializers/spree/wombat/address_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/adjustment_serializer.rb
+++ b/app/serializers/spree/wombat/adjustment_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/customer_return_serializer.rb
+++ b/app/serializers/spree/wombat/customer_return_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/image_serializer.rb
+++ b/app/serializers/spree/wombat/image_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/inventory_unit_serializer.rb
+++ b/app/serializers/spree/wombat/inventory_unit_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/line_item_serializer.rb
+++ b/app/serializers/spree/wombat/line_item_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/order_serializer.rb
+++ b/app/serializers/spree/wombat/order_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/payment_serializer.rb
+++ b/app/serializers/spree/wombat/payment_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/product_serializer.rb
+++ b/app/serializers/spree/wombat/product_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat
@@ -6,8 +6,14 @@ module Spree
 
       attributes :id, :name, :sku, :description, :price, :cost_price,
                  :available_on, :permalink, :meta_description, :meta_keywords,
-                 :shipping_category, :taxons, :options, :weight, :height, :width,
+                 :shipping_category, :taxons, :weight, :height, :width,
                  :depth, :variants
+
+      def attributes
+        super.tap do |hash|
+          hash.update(options: options_text)
+        end
+      end
 
       has_many :images, serializer: Spree::Wombat::ImageSerializer
 
@@ -39,7 +45,7 @@ module Spree
         object.taxons.collect {|t| t.self_and_ancestors.collect(&:name)}
       end
 
-      def options
+      def options_text
         object.option_types.pluck(:name)
       end
 

--- a/app/serializers/spree/wombat/promotion_serializer.rb
+++ b/app/serializers/spree/wombat/promotion_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/refund_serializer.rb
+++ b/app/serializers/spree/wombat/refund_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/reimbursement_serializer.rb
+++ b/app/serializers/spree/wombat/reimbursement_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/responder_serializer.rb
+++ b/app/serializers/spree/wombat/responder_serializer.rb
@@ -1,18 +1,15 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat
     class ResponderSerializer < ActiveModel::Serializer
       attributes :request_id, :summary, :backtrace, :objects
 
-      def filter(keys)
-        keys.delete(:backtrace) if object.exception.nil?
-        keys.delete(:objects) unless object.objects.present?
-        keys
-      end
-
       def attributes
         hash = super
+
+        hash.delete(:backtrace) if object.exception.nil?
+        hash.delete(:objects) unless object.objects.present?
 
         if objects = hash.delete(:objects)
           objects.each do |key, array_of_objects|

--- a/app/serializers/spree/wombat/return_item_serializer.rb
+++ b/app/serializers/spree/wombat/return_item_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/shipment_serializer.rb
+++ b/app/serializers/spree/wombat/shipment_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat
@@ -7,8 +7,8 @@ module Spree
                 :shipping_method, :tracking, :placed_on, :shipped_at, :totals,
                 :updated_at, :channel, :items
 
-      has_one :bill_to, serializer: AddressSerializer, root: "billing_address"
-      has_one :ship_to, serializer: AddressSerializer, root: "shipping_address"
+      has_one :bill_to, serializer: AddressSerializer, key: "billing_address"
+      has_one :ship_to, serializer: AddressSerializer, key: "shipping_address"
 
       def id
         object.number

--- a/app/serializers/spree/wombat/source_serializer.rb
+++ b/app/serializers/spree/wombat/source_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/stock_item_serializer.rb
+++ b/app/serializers/spree/wombat/stock_item_serializer.rb
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat

--- a/app/serializers/spree/wombat/variant_serializer.rb
+++ b/app/serializers/spree/wombat/variant_serializer.rb
@@ -1,11 +1,17 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 module Spree
   module Wombat
     class VariantSerializer < ActiveModel::Serializer
 
-      attributes :sku, :price, :cost_price, :options, :weight, :height, :width, :depth
+      attributes :sku, :price, :cost_price, :weight, :height, :width, :depth
       has_many :images, serializer: Spree::Wombat::ImageSerializer
+
+      def attributes
+        super.tap do |hash|
+          hash.update(options: options_text)
+        end
+      end
 
       def price
         object.price.to_f
@@ -15,7 +21,7 @@ module Spree
         object.cost_price.to_f
       end
 
-      def options
+      def options_text
         object.option_values.each_with_object({}) {|ov,h| h[ov.option_type.presentation]= ov.presentation}
       end
 

--- a/lib/generators/spree_wombat/serializer/templates/serializer.rb.tt
+++ b/lib/generators/spree_wombat/serializer/templates/serializer.rb.tt
@@ -1,4 +1,4 @@
-require 'active_model/serializer'
+require 'active_model_serializers'
 <% if superclass != "ActiveModel::Serializer" %>
 # inherit from ActiveModel::Serializer if you want to completely replace the existing serializer
 <% end %>

--- a/lib/spree/wombat/responder.rb
+++ b/lib/spree/wombat/responder.rb
@@ -1,11 +1,10 @@
-require "active_model/serializer_support"
-
 module Spree
   module Wombat
     class Responder
       class ErroredResponse < StandardError; end
 
-      include ActiveModel::SerializerSupport
+      alias read_attribute_for_serialization send
+
       attr_accessor :request_id, :summary, :code, :objects, :exception
 
       def initialize(request_id, summary, code=200, objects=nil, exception=nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
-require 'active_model/serializer'
+require 'active_model_serializers'
 
 RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = '2.2.0'
 
   gem.add_dependency 'spree_core', '~> 3.1.0.beta'
-  gem.add_dependency 'active_model_serializers', '0.9.0.alpha1'
+  gem.add_dependency 'active_model_serializers', '~> 0.8.3'
   gem.add_dependency 'httparty'
 
   gem.add_development_dependency 'capybara', '~> 2.1'


### PR DESCRIPTION
At present, `spree_wombat` depends on the 0.9.x branch of `active_model_serializers`. Development along this branch appears [to be defunct](https://github.com/rails-api/active_model_serializers#maintenance-please-read), with the rails-api team opting to work on an 0.10.x branch based off the 0.8.x branch. Phew, confusing!

Given the roadmap for AMS, I propose that it makes more sense to depend on the 0.8.x branch than the 0.9.x branch. This PR changes the version of `active_model_serializers` on which `spree_wombat` depends, and small changes to the serializers to keep the test suite green.

The PR targets the `master` branch now, but can be back-ported pretty easily into other branches.