### PR TITLE
Add shipping_method code

### DIFF
--- a/app/serializers/spree/wombat/shipment_serializer.rb
+++ b/app/serializers/spree/wombat/shipment_serializer.rb
@@ -5,7 +5,7 @@ module Spree
     class ShipmentSerializer < ActiveModel::Serializer
       attributes :id, :order_id, :email, :cost, :status, :stock_location,
                 :shipping_method, :tracking, :placed_on, :shipped_at, :totals,
-                :updated_at, :channel, :items
+                :updated_at, :channel, :items, :shipping_method_code
 
       has_one :bill_to, serializer: AddressSerializer, key: "billing_address"
       has_one :ship_to, serializer: AddressSerializer, key: "shipping_address"
@@ -40,6 +40,10 @@ module Spree
 
       def shipping_method
         object.shipping_method.try(:name)
+      end
+      
+      def shipping_method_code
+        object.shipping_method.try(:code)  
       end
 
       def placed_on


### PR DESCRIPTION
In 2-4-stable a code field was used for shipping methods. Here is the intention:

> The expectation, like a sku, is that a shipping_method.code could represent an immutable value 
> that is safe to bind against when figuring out what shipping method to use.