### PR TITLE
Fix bug in update_shipment hook

### DIFF
--- a/lib/spree/wombat/handler/shipment_handler_base.rb
+++ b/lib/spree/wombat/handler/shipment_handler_base.rb
@@ -53,7 +53,8 @@ module Spree
           shipping_items.each do |shipping_item|
             # get variant
             sku = shipping_item[:product_id]
-            variant = Spree::Variant.find_by_sku(sku)
+            variant = Spree::Variant.active.find_by_sku(sku) ||
+                        Spree::Variant.deleted.find_by_sku(sku)
 
             unless variant.present?
               missing_variants << sku


### PR DESCRIPTION
The bug occurs whenever an order contains a variant with the same SKU as a deleted variant with a lower id. The error thrown is a "Can't find line items with SKU . . ." error created [here](https://github.com/spree/spree_wombat/blob/f3a5eaba74d46a8254760fa094fbfcb3bbdc38a9/lib/spree/wombat/handler/update_shipment_handler.rb#L26).

I've had a lot of these errors clogging up my instance of wombat on a recurring basis. I imagine anyone else who has replaced old variants with new versions that have the same SKUs has them as well.