### PR TITLE
Add taxonomy when creating a taxon.

### DIFF
--- a/lib/spree/wombat/handler/product_handler_base.rb
+++ b/lib/spree/wombat/handler/product_handler_base.rb
@@ -91,7 +91,7 @@ module Spree
           if taxon
             parent.children << taxon
           else
-            taxon = parent.children.create!(name: taxon_name, position: position)
+            taxon = parent.children.create!(name: taxon_name, position: position, taxonomy: parent.taxonomy)
           end
           parent.save
           # store the taxon so we can assign it later


### PR DESCRIPTION
Why:

* A valid taxon must have a taxonomy associated.

This change addresses the need by:

* Add taxonomy when creating a taxon.